### PR TITLE
[#43] : 결제 실패시 재처리 및 이벤트 관리 구현

### DIFF
--- a/item-api/src/main/java/com/example/itemapi/global/aop/DistributedLockAop.java
+++ b/item-api/src/main/java/com/example/itemapi/global/aop/DistributedLockAop.java
@@ -8,13 +8,13 @@ import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.reflect.MethodSignature;
 import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
-import org.springframework.context.annotation.Primary;
+import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
 import java.lang.reflect.Method;
 
-@Order(Integer.MIN_VALUE)
+@Order(Ordered.HIGHEST_PRECEDENCE)
 @Aspect
 @Component
 @Slf4j

--- a/order-api/src/main/java/com/example/orderapi/application/service/EventFailedService.java
+++ b/order-api/src/main/java/com/example/orderapi/application/service/EventFailedService.java
@@ -1,0 +1,22 @@
+package com.example.orderapi.application.service;
+
+import com.example.orderapi.domain.model.EventFailed;
+import com.example.orderapi.domain.repository.EventFailedRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class EventFailedService {
+
+    private final EventFailedRepository eventFailedRepository;
+
+    public void create(String type, String payload) {
+        EventFailed eventFailed = EventFailed.builder()
+                .eventType(type)
+                .payload(payload)
+                .build();
+
+        eventFailedRepository.save(eventFailed);
+    }
+}

--- a/order-api/src/main/java/com/example/orderapi/application/service/listener/OrderEventListener.java
+++ b/order-api/src/main/java/com/example/orderapi/application/service/listener/OrderEventListener.java
@@ -1,7 +1,9 @@
 package com.example.orderapi.application.service.listener;
 
+import com.example.orderapi.application.service.EventFailedService;
 import com.example.orderapi.application.service.OrderService;
 import com.example.orderapi.application.service.listener.dto.OrderPaymentCompleteEvent;
+import com.example.orderapi.application.service.listener.dto.OrderPaymentFailedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
@@ -15,6 +17,7 @@ import org.springframework.transaction.event.TransactionalEventListener;
 public class OrderEventListener {
 
     private final OrderService orderService;
+    private final EventFailedService eventFailedService;
 
     @Async("eventAsyncExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
@@ -22,5 +25,14 @@ public class OrderEventListener {
         log.info("결제 완료 처리");
         orderService.paymentComplete(event.orderId(), event.itemId(), event.decreaseCount());
         log.info("모두 완료");
+    }
+
+
+    @Async("eventAsyncExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_ROLLBACK)
+    public void paymentFailed(OrderPaymentFailedEvent event) {
+        log.info("결제 실패 처리");
+        eventFailedService.create(event.eventType(), event.payload());
+        log.info("실패 완료");
     }
 }

--- a/order-api/src/main/java/com/example/orderapi/application/service/listener/dto/OrderPaymentFailedEvent.java
+++ b/order-api/src/main/java/com/example/orderapi/application/service/listener/dto/OrderPaymentFailedEvent.java
@@ -1,0 +1,7 @@
+package com.example.orderapi.application.service.listener.dto;
+
+public record OrderPaymentFailedEvent(
+        String eventType,
+        String payload
+) {
+}

--- a/order-api/src/main/java/com/example/orderapi/domain/model/EventFailed.java
+++ b/order-api/src/main/java/com/example/orderapi/domain/model/EventFailed.java
@@ -1,0 +1,31 @@
+package com.example.orderapi.domain.model;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "event_failed")
+public class EventFailed {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "event_id")
+    private Long id;
+
+    @Column(name = "event_type", nullable = false)
+    private String eventType;
+
+    @Column(name = "payload", nullable = false)
+    private String payload;
+
+    @Builder
+    public EventFailed(String eventType, String payload) {
+        this.eventType = eventType;
+        this.payload = payload;
+    }
+}

--- a/order-api/src/main/java/com/example/orderapi/domain/repository/EventFailedRepository.java
+++ b/order-api/src/main/java/com/example/orderapi/domain/repository/EventFailedRepository.java
@@ -1,0 +1,8 @@
+package com.example.orderapi.domain.repository;
+
+import com.example.orderapi.domain.model.EventFailed;
+
+public interface EventFailedRepository {
+
+    EventFailed save(EventFailed eventFailed);
+}

--- a/order-api/src/main/java/com/example/orderapi/global/exception/PaymentFeignClientErrorDecoder.java
+++ b/order-api/src/main/java/com/example/orderapi/global/exception/PaymentFeignClientErrorDecoder.java
@@ -1,5 +1,7 @@
 package com.example.orderapi.global.exception;
 
+import org.springframework.http.HttpStatus;
+
 import feign.Response;
 import feign.RetryableException;
 import feign.codec.ErrorDecoder;

--- a/order-api/src/main/java/com/example/orderapi/global/exception/PaymentFeignClientErrorDecoder.java
+++ b/order-api/src/main/java/com/example/orderapi/global/exception/PaymentFeignClientErrorDecoder.java
@@ -9,8 +9,8 @@ public class PaymentFeignClientErrorDecoder implements ErrorDecoder {
 
     @Override
     public Exception decode(String s, Response response) {
-        if (500 == response.status()) {
-            return new RetryableException(500, response.reason(), response.request().httpMethod(), (Long) null, response.request());
+        if (HttpStatus.valueOf(response.status()).is5xxServerError()) {
+            return new RetryableException(response.status(), response.reason(), response.request().httpMethod(), (Long) null, response.request());
         }
 
         return decoder.decode(s, response);

--- a/order-api/src/main/java/com/example/orderapi/global/exception/PaymentFeignClientErrorDecoder.java
+++ b/order-api/src/main/java/com/example/orderapi/global/exception/PaymentFeignClientErrorDecoder.java
@@ -1,0 +1,18 @@
+package com.example.orderapi.global.exception;
+
+import feign.Response;
+import feign.RetryableException;
+import feign.codec.ErrorDecoder;
+
+public class PaymentFeignClientErrorDecoder implements ErrorDecoder {
+    private final ErrorDecoder decoder = new Default();
+
+    @Override
+    public Exception decode(String s, Response response) {
+        if (500 == response.status()) {
+            return new RetryableException(500, response.reason(), response.request().httpMethod(), (Long) null, response.request());
+        }
+
+        return decoder.decode(s, response);
+    }
+}

--- a/order-api/src/main/java/com/example/orderapi/global/utils/ObjectMapperUtils.java
+++ b/order-api/src/main/java/com/example/orderapi/global/utils/ObjectMapperUtils.java
@@ -1,0 +1,23 @@
+package com.example.orderapi.global.utils;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class ObjectMapperUtils {
+
+    public static ObjectMapper objectMapper() {
+        return new ObjectMapper();
+    }
+
+    public static String createObjectToJson(Object obj) {
+        try {
+            return objectMapper().writeValueAsString(obj);
+        } catch (JsonProcessingException e) {
+            log.error("JSON 변경 오류");
+        }
+
+        return "";
+    }
+}

--- a/order-api/src/main/java/com/example/orderapi/infrastructure/persistence/EventFailedJpaRepository.java
+++ b/order-api/src/main/java/com/example/orderapi/infrastructure/persistence/EventFailedJpaRepository.java
@@ -1,0 +1,8 @@
+package com.example.orderapi.infrastructure.persistence;
+
+import com.example.orderapi.domain.model.EventFailed;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EventFailedJpaRepository extends JpaRepository<EventFailed, Long> {
+}
+

--- a/order-api/src/main/java/com/example/orderapi/infrastructure/persistence/EventFailedRepositoryImpl.java
+++ b/order-api/src/main/java/com/example/orderapi/infrastructure/persistence/EventFailedRepositoryImpl.java
@@ -1,0 +1,19 @@
+package com.example.orderapi.infrastructure.persistence;
+
+import com.example.orderapi.domain.model.EventFailed;
+import com.example.orderapi.domain.repository.EventFailedRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class EventFailedRepositoryImpl implements EventFailedRepository {
+
+    private final EventFailedJpaRepository repository;
+
+
+    @Override
+    public EventFailed save(EventFailed eventFailed) {
+        return repository.save(eventFailed);
+    }
+}

--- a/order-api/src/main/java/com/example/orderapi/interfaces/presentation/feign/PaymentClient.java
+++ b/order-api/src/main/java/com/example/orderapi/interfaces/presentation/feign/PaymentClient.java
@@ -3,11 +3,12 @@ package com.example.orderapi.interfaces.presentation.feign;
 import com.example.orderapi.application.service.dto.request.PaymentCancelRequest;
 import com.example.orderapi.application.service.dto.request.PaymentRequest;
 import com.example.orderapi.application.service.dto.response.PaymentResultResponse;
+import com.example.orderapi.global.exception.PaymentFeignClientErrorDecoder;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
-@FeignClient(value = "paymentClient", url = "http://localhost:8082/api/v1")
+@FeignClient(value = "paymentClient", url = "http://localhost:8082/api/v1", configuration = PaymentFeignClientErrorDecoder.class)
 public interface PaymentClient {
 
     @PostMapping(value = "/payments", consumes = "application/json; charset=UTF-8")


### PR DESCRIPTION
- 기존에 Feign 재처리를 설정 했으나 Feign은 기본적으로 IOException만 재처리 한다고 하여 다른 에러도 재처리 할 수 있게 추가하였습니다.
- event fail을 관리할 목적으로 DB에 저장하는 로직을 구현하였습니다.

감사합니다.