### PR TITLE
[#33] : 재고 차감, 주문 상태 실패시 이벤트 재처리 및 이벤트 데이터 관리 구현

### DIFF
--- a/item-api/src/main/java/com/example/itemapi/application/service/EventFailedService.java
+++ b/item-api/src/main/java/com/example/itemapi/application/service/EventFailedService.java
@@ -1,0 +1,24 @@
+package com.example.itemapi.application.service;
+
+import org.springframework.stereotype.Service;
+
+import com.example.itemapi.domain.model.EventFailed;
+import com.example.itemapi.domain.repository.EventFailedRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Service
+public class EventFailedService {
+
+    private final EventFailedRepository eventFailedRepository;
+
+    public void create(String type, String payload) {
+        EventFailed eventFailed = EventFailed.builder()
+                .eventType(type)
+                .payload(payload)
+                .build();
+
+        eventFailedRepository.save(eventFailed);
+    }
+}

--- a/item-api/src/main/java/com/example/itemapi/application/service/ItemService.java
+++ b/item-api/src/main/java/com/example/itemapi/application/service/ItemService.java
@@ -1,15 +1,17 @@
 package com.example.itemapi.application.service;
 
+import java.math.BigDecimal;
+
+import org.springframework.stereotype.Service;
+
 import com.example.itemapi.application.service.dto.ItemServiceDto;
 import com.example.itemapi.domain.manager.ItemManager;
 import com.example.itemapi.domain.model.Item;
 import com.example.itemapi.global.config.TopicNames;
 import com.example.itemapi.kafka.OrderEventProducer;
 import com.example.kafka.OrderCompleteEvent;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
 
-import java.math.BigDecimal;
+import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @Service

--- a/item-api/src/main/java/com/example/itemapi/domain/model/EventFailed.java
+++ b/item-api/src/main/java/com/example/itemapi/domain/model/EventFailed.java
@@ -1,0 +1,36 @@
+package com.example.itemapi.domain.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "event_failed")
+public class EventFailed {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "event_id")
+    private Long id;
+
+    @Column(name = "event_type", nullable = false)
+    private String eventType;
+
+    @Column(name = "payload", nullable = false)
+    private String payload;
+
+    @Builder
+    public EventFailed(String eventType, String payload) {
+        this.eventType = eventType;
+        this.payload = payload;
+    }
+}

--- a/item-api/src/main/java/com/example/itemapi/domain/repository/EventFailedRepository.java
+++ b/item-api/src/main/java/com/example/itemapi/domain/repository/EventFailedRepository.java
@@ -1,0 +1,8 @@
+package com.example.itemapi.domain.repository;
+
+import com.example.itemapi.domain.model.EventFailed;
+
+public interface EventFailedRepository {
+
+    EventFailed save(EventFailed eventFailed);
+}

--- a/item-api/src/main/java/com/example/itemapi/global/config/KafkaConsumerConfig.java
+++ b/item-api/src/main/java/com/example/itemapi/global/config/KafkaConsumerConfig.java
@@ -1,8 +1,8 @@
 package com.example.itemapi.global.config;
 
-import com.example.kafka.Event;
-import io.confluent.kafka.serializers.KafkaAvroDeserializer;
-import lombok.extern.slf4j.Slf4j;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.springframework.context.annotation.Bean;
@@ -11,14 +11,21 @@ import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.listener.CommonErrorHandler;
 import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
 import org.springframework.kafka.listener.DefaultErrorHandler;
 import org.springframework.util.backoff.FixedBackOff;
 
-import java.util.HashMap;
-import java.util.Map;
+import com.example.kafka.Event;
+
+import io.confluent.kafka.serializers.KafkaAvroDeserializer;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
+@RequiredArgsConstructor
 @EnableKafka
 @Configuration
 public class KafkaConsumerConfig {
@@ -27,6 +34,8 @@ public class KafkaConsumerConfig {
 
 	private static final String SCHEMA_REGISTRY_URL_CONFIG = "schema.registry.url";
 	private static final String SCHEMA_REGISTRY_URL = "http://localhost:9001";
+
+	private final KafkaTemplate<String, Event> kafkaTemplate;
 
 	@Bean
 	public ConsumerFactory<String, Event> consumerFactory() {
@@ -52,9 +61,9 @@ public class KafkaConsumerConfig {
 		return factory;
 	}
 
-	private DefaultErrorHandler errorHandler() {
-		return new DefaultErrorHandler((record, e) -> {
-			log.error("record : {}, exception : {}", record, e.getCause());
-		}, new FixedBackOff(1000L, 3L));
+	@Bean
+	public CommonErrorHandler errorHandler() {
+		DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(kafkaTemplate);
+		return new DefaultErrorHandler(recoverer, new FixedBackOff(1000L, 3L));
 	}
 }

--- a/item-api/src/main/java/com/example/itemapi/global/config/KafkaConsumerConfig.java
+++ b/item-api/src/main/java/com/example/itemapi/global/config/KafkaConsumerConfig.java
@@ -13,7 +13,6 @@ import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.listener.CommonErrorHandler;
-import org.springframework.kafka.listener.ContainerProperties;
 import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
 import org.springframework.kafka.listener.DefaultErrorHandler;
 import org.springframework.util.backoff.FixedBackOff;
@@ -54,9 +53,6 @@ public class KafkaConsumerConfig {
 		ConcurrentKafkaListenerContainerFactory<String, Event> factory = new ConcurrentKafkaListenerContainerFactory<>();
 		factory.setConsumerFactory(consumerFactory());
 		factory.setCommonErrorHandler(errorHandler());
-
-		ContainerProperties containerProperties = factory.getContainerProperties();
-		containerProperties.setAckMode(ContainerProperties.AckMode.MANUAL_IMMEDIATE);
 
 		return factory;
 	}

--- a/item-api/src/main/java/com/example/itemapi/global/config/TopicNames.java
+++ b/item-api/src/main/java/com/example/itemapi/global/config/TopicNames.java
@@ -4,5 +4,7 @@ public class TopicNames {
 
 	public static final String ITEM_DECREASE_STOCK_TOPIC = "item-decrease-stock-result";
 
+	public static final String ITEM_DECREASE_STOCK_DLT_TOPIC = "item-decrease-stock-result-dlt";
+
 	public static final String ORDER_RESULT_TOPIC = "order-result";
 }

--- a/item-api/src/main/java/com/example/itemapi/infrastructure/persistence/EventFailedJpaRepository.java
+++ b/item-api/src/main/java/com/example/itemapi/infrastructure/persistence/EventFailedJpaRepository.java
@@ -1,0 +1,8 @@
+package com.example.itemapi.infrastructure.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.example.itemapi.domain.model.EventFailed;
+
+public interface EventFailedJpaRepository extends JpaRepository<EventFailed, Long> {
+}

--- a/item-api/src/main/java/com/example/itemapi/infrastructure/persistence/EventFailedRepositoryImpl.java
+++ b/item-api/src/main/java/com/example/itemapi/infrastructure/persistence/EventFailedRepositoryImpl.java
@@ -1,0 +1,21 @@
+package com.example.itemapi.infrastructure.persistence;
+
+import org.springframework.stereotype.Repository;
+
+import com.example.itemapi.domain.model.EventFailed;
+import com.example.itemapi.domain.repository.EventFailedRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Repository
+public class EventFailedRepositoryImpl implements EventFailedRepository {
+
+    private final EventFailedJpaRepository repository;
+
+
+    @Override
+    public EventFailed save(EventFailed eventFailed) {
+        return repository.save(eventFailed);
+    }
+}

--- a/item-api/src/main/java/com/example/itemapi/kafka/ItemResultConsumer.java
+++ b/item-api/src/main/java/com/example/itemapi/kafka/ItemResultConsumer.java
@@ -2,7 +2,6 @@ package com.example.itemapi.kafka;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.springframework.kafka.annotation.KafkaListener;
-import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Component;
 
 import com.example.itemapi.application.service.EventFailedService;
@@ -22,8 +21,8 @@ public class ItemResultConsumer {
 	private final ItemService itemService;
 	private final EventFailedService eventFailedService;
 
-	@KafkaListener(topics = TopicNames.ITEM_DECREASE_STOCK_TOPIC, groupId = "item-group")
-	public void onCommandEvent(ConsumerRecord<String, Event> record, Acknowledgment acknowledgment) {
+	@KafkaListener(topics = TopicNames.ITEM_DECREASE_STOCK_TOPIC, groupId = "item-group", containerFactory = "kafkaListenerContainerFactory")
+	public void onCommandEvent(ConsumerRecord<String, Event> record) {
 		log.info("Publish command event: {}", record.value());
 		Object event = record.value().getEvent();
 
@@ -31,8 +30,6 @@ public class ItemResultConsumer {
 			DecreaseStockEvent decreaseStockEvent = (DecreaseStockEvent)event;
 			itemService.decreaseStock(decreaseStockEvent.getOrderId(), decreaseStockEvent.getItemId(), decreaseStockEvent.getDecreaseCount());
 		}
-
-		acknowledgment.acknowledge();
 	}
 
 	@KafkaListener(topics = TopicNames.ITEM_DECREASE_STOCK_DLT_TOPIC, groupId = "item-group", containerFactory = "kafkaListenerContainerFactory")

--- a/item-api/src/main/java/com/example/itemapi/kafka/ItemResultConsumer.java
+++ b/item-api/src/main/java/com/example/itemapi/kafka/ItemResultConsumer.java
@@ -5,6 +5,7 @@ import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Component;
 
+import com.example.itemapi.application.service.EventFailedService;
 import com.example.itemapi.application.service.ItemService;
 import com.example.itemapi.global.config.TopicNames;
 import com.example.kafka.DecreaseStockEvent;
@@ -19,6 +20,7 @@ import lombok.extern.slf4j.Slf4j;
 public class ItemResultConsumer {
 
 	private final ItemService itemService;
+	private final EventFailedService eventFailedService;
 
 	@KafkaListener(topics = TopicNames.ITEM_DECREASE_STOCK_TOPIC, groupId = "item-group")
 	public void onCommandEvent(ConsumerRecord<String, Event> record, Acknowledgment acknowledgment) {
@@ -31,5 +33,13 @@ public class ItemResultConsumer {
 		}
 
 		acknowledgment.acknowledge();
+	}
+
+	@KafkaListener(topics = TopicNames.ITEM_DECREASE_STOCK_DLT_TOPIC, groupId = "item-group", containerFactory = "kafkaListenerContainerFactory")
+	public void onDLTEvent(ConsumerRecord<String, Event> record) {
+		Event event = record.value();
+		log.info("DLT Publish command event: {}", event);
+
+		eventFailedService.create(event.getEventType(), event.getEvent().toString());
 	}
 }

--- a/order-api/src/main/java/com/example/orderapi/application/service/OrderService.java
+++ b/order-api/src/main/java/com/example/orderapi/application/service/OrderService.java
@@ -61,7 +61,7 @@ public class OrderService {
             // 결제 실패
             // 로그를 남겨 따로 관리
             // 이벤트 처리
-            applicationEventPublisher.publishEvent(new OrderPaymentFailedEvent(paymentRequest.getClass().getSimpleName(),
+            applicationEventPublisher.publishEvent(new OrderPaymentFailedEvent(paymentRequest.getClass().getName(),
                     ObjectMapperUtils.createObjectToJson(paymentRequest)));
 
             log.error("결제 실패");

--- a/order-api/src/main/java/com/example/orderapi/global/config/KafkaConsumerConfig.java
+++ b/order-api/src/main/java/com/example/orderapi/global/config/KafkaConsumerConfig.java
@@ -1,9 +1,8 @@
 package com.example.orderapi.global.config;
 
-import com.example.kafka.Event;
-import io.confluent.kafka.serializers.KafkaAvroDeserializer;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.springframework.context.annotation.Bean;
@@ -18,8 +17,11 @@ import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
 import org.springframework.kafka.listener.DefaultErrorHandler;
 import org.springframework.util.backoff.FixedBackOff;
 
-import java.util.HashMap;
-import java.util.Map;
+import com.example.kafka.Event;
+
+import io.confluent.kafka.serializers.KafkaAvroDeserializer;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -57,10 +59,6 @@ public class KafkaConsumerConfig {
 
 	@Bean
 	public CommonErrorHandler errorHandler() {
-//		return new DefaultErrorHandler((record, e) -> {
-//			log.error("record : {}, exception : {}", record, e.getCause());
-//			new DeadLetterPublishingRecoverer(kafkaTemplate);
-//		}, new FixedBackOff(1000L, 3L));
 		DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(kafkaTemplate);
 		return new DefaultErrorHandler(recoverer, new FixedBackOff(1000L, 3L));
 	}

--- a/order-api/src/main/java/com/example/orderapi/global/config/KafkaProducerConfig.java
+++ b/order-api/src/main/java/com/example/orderapi/global/config/KafkaProducerConfig.java
@@ -43,7 +43,8 @@ public class KafkaProducerConfig {
 	@Bean
 	public List<NewTopic> topics() {
 		return List.of(
-			new NewTopic(TopicNames.ORDER_RESULT_TOPIC, 1, (short)1)
+				new NewTopic(TopicNames.ORDER_RESULT_TOPIC, 1, (short)1),
+				new NewTopic(TopicNames.ORDER_DLT_TOPIC, 1, (short)1)
 		);
 	}
 }

--- a/order-api/src/main/java/com/example/orderapi/global/config/TopicNames.java
+++ b/order-api/src/main/java/com/example/orderapi/global/config/TopicNames.java
@@ -5,4 +5,6 @@ public class TopicNames {
 	public static final String ITEM_DECREASE_STOCK_TOPIC = "item-decrease-stock-result";
 
 	public static final String ORDER_RESULT_TOPIC = "order-result";
+
+	public static final String ORDER_DLT_TOPIC = "order-dlt.DLT";
 }

--- a/order-api/src/main/java/com/example/orderapi/global/config/TopicNames.java
+++ b/order-api/src/main/java/com/example/orderapi/global/config/TopicNames.java
@@ -6,5 +6,5 @@ public class TopicNames {
 
 	public static final String ORDER_RESULT_TOPIC = "order-result";
 
-	public static final String ORDER_DLT_TOPIC = "order-dlt.DLT";
+	public static final String ORDER_DLT_TOPIC = "order-result-dlt";
 }

--- a/order-api/src/main/java/com/example/orderapi/kafka/OrderResultConsumer.java
+++ b/order-api/src/main/java/com/example/orderapi/kafka/OrderResultConsumer.java
@@ -1,15 +1,18 @@
 package com.example.orderapi.kafka;
 
-import com.example.kafka.Event;
-import com.example.orderapi.global.config.TopicNames;
-import com.example.orderapi.kafka.dispatcher.OrderDispatcher;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import java.util.List;
+
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
+import com.example.kafka.Event;
+import com.example.orderapi.application.service.EventFailedService;
+import com.example.orderapi.global.config.TopicNames;
+import com.example.orderapi.kafka.dispatcher.OrderDispatcher;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -17,6 +20,7 @@ import java.util.List;
 public class OrderResultConsumer {
 
 	private final List<OrderDispatcher> orderDispatchers;
+	private final EventFailedService eventFailedService;
 
 	@KafkaListener(topics = TopicNames.ORDER_RESULT_TOPIC, groupId = "order-group", containerFactory = "kafkaListenerContainerFactory")
 	public void onCommandEvent(ConsumerRecord<String, Event> record) {
@@ -33,8 +37,10 @@ public class OrderResultConsumer {
 	}
 
 	@KafkaListener(topics = TopicNames.ORDER_DLT_TOPIC, groupId = "order-group", containerFactory = "kafkaListenerContainerFactory")
-	public void onCommandEvent2(ConsumerRecord<String, Event> record) {
+	public void onDLTEvent(ConsumerRecord<String, Event> record) {
 		Event event = record.value();
 		log.info("DLT Publish command event: {}", event);
+
+		eventFailedService.create(event.getEventType(), event.getEvent().toString());
 	}
 }

--- a/order-api/src/main/java/com/example/orderapi/kafka/OrderResultConsumer.java
+++ b/order-api/src/main/java/com/example/orderapi/kafka/OrderResultConsumer.java
@@ -18,17 +18,23 @@ public class OrderResultConsumer {
 
 	private final List<OrderDispatcher> orderDispatchers;
 
-	@KafkaListener(topics = TopicNames.ORDER_RESULT_TOPIC, groupId = "order-group")
+	@KafkaListener(topics = TopicNames.ORDER_RESULT_TOPIC, groupId = "order-group", containerFactory = "kafkaListenerContainerFactory")
 	public void onCommandEvent(ConsumerRecord<String, Event> record) {
-		log.info("Publish command event: {}", record.value());
-		Object event = record.value().getEvent();
+		Event event = record.value();
+		log.info("Publish command event: {}", event);
 
 		orderDispatchers.stream()
-				.filter(it -> it.supports(event))
+				.filter(it -> it.supports(event.getEventType()))
 				.findFirst()
 				.ifPresentOrElse(
-						it -> it.execute(event),
+						it -> it.execute(event.getEvent()),
 						() -> log.warn("해당 이벤트를 처리할 수 없습니다.")
 				);
+	}
+
+	@KafkaListener(topics = TopicNames.ORDER_DLT_TOPIC, groupId = "order-group", containerFactory = "kafkaListenerContainerFactory")
+	public void onCommandEvent2(ConsumerRecord<String, Event> record) {
+		Event event = record.value();
+		log.info("DLT Publish command event: {}", event);
 	}
 }

--- a/order-api/src/main/java/com/example/orderapi/kafka/dispatcher/OrderCompleteDispatcher.java
+++ b/order-api/src/main/java/com/example/orderapi/kafka/dispatcher/OrderCompleteDispatcher.java
@@ -18,9 +18,6 @@ public class OrderCompleteDispatcher implements OrderDispatcher<OrderCompleteEve
 
     @Override
     public void execute(OrderCompleteEvent event) {
-        if (true) {
-            throw new IllegalArgumentException("");
-        }
         orderService.orderComplete(event.getOrderId());
     }
 }

--- a/order-api/src/main/java/com/example/orderapi/kafka/dispatcher/OrderCompleteDispatcher.java
+++ b/order-api/src/main/java/com/example/orderapi/kafka/dispatcher/OrderCompleteDispatcher.java
@@ -12,12 +12,15 @@ public class OrderCompleteDispatcher implements OrderDispatcher<OrderCompleteEve
     private final OrderService orderService;
 
     @Override
-    public boolean supports(Object event) {
-        return event instanceof OrderCompleteEvent;
+    public boolean supports(String event) {
+        return event.equals(OrderCompleteEvent.class.getName());
     }
 
     @Override
     public void execute(OrderCompleteEvent event) {
+        if (true) {
+            throw new IllegalArgumentException("");
+        }
         orderService.orderComplete(event.getOrderId());
     }
 }

--- a/order-api/src/main/java/com/example/orderapi/kafka/dispatcher/OrderDispatcher.java
+++ b/order-api/src/main/java/com/example/orderapi/kafka/dispatcher/OrderDispatcher.java
@@ -2,7 +2,7 @@ package com.example.orderapi.kafka.dispatcher;
 
 public interface OrderDispatcher<T> {
 
-    boolean supports(Object event);
+    boolean supports(String event);
 
     void execute(T event);
 }


### PR DESCRIPTION
- 이벤트 실패시 DLQ를 사용하여 재처리 시도를 합니다. 현재는 기존 kafka를 재사용 합니다.
- 이벤트 재처리 후에도 계속 실패가 된다면 DB에 이벤트를 저장합니다.

감사합니다.